### PR TITLE
chore: clarify the reason .go uses LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,10 @@ end_of_line = lf
 [{*.bat,*.cmd}]
 end_of_line = crlf
 
+[*.go]
+# gofmt defaults to LF for all the platforms: https://github.com/golang/go/issues/16355
+end_of_line = lf
+
 [*.md]
 # Trailing whitespace is important in Markdown (they distinguish a new line from a new paragraph)
 eclint_indent_style = unset

--- a/.gitattributes
+++ b/.gitattributes
@@ -45,6 +45,7 @@ Dockerfile text
 # Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf
+# gofmt defaults to LF for all the platforms: https://github.com/golang/go/issues/16355
 *.go text eol=lf
 
 ###############################


### PR DESCRIPTION
LF is the only option given by gofmt
See https://github.com/golang/go/issues/16355