### PR TITLE
fix: generic bug_report.yml should not be hard-coded to Profiler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       description: |
         A clear and concise description of what the bug is.
       placeholder: |
-        When I do `A` Profiler/Profiler Agent does `B`. I expect it to do `C`.
+        When I perform `use case` I expect `expected result` while the `actual result` is different.
     validations:
       required: true
   - type: textarea
@@ -28,15 +28,15 @@ body:
     attributes:
       label: Version
       description: |
-        Check the `version.txt` file inside the profiler agent directory.
+        Version of the related components
     validations:
-      required: true
+      required: false
   - type: textarea
     id: logs
     attributes:
       label: Logs
       description: |
-        Check if any warnings or errors were logged by Profiler
+        Check if any warnings or errors if relevant
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Previously, textfield placeholders included "Profiler" which sounds strange for a generic issue template.