### PR TITLE
fix: use checkstyle.xml in super-linter

### DIFF
--- a/config/linters/super-linter.env
+++ b/config/linters/super-linter.env
@@ -3,6 +3,9 @@
 # name=value
 # Commented VALIDATE_* means that the check is ON.
 
+# By default, super-linter uses sun_checks.xml, while we have checkstyle.xml instead
+JAVA_FILE_NAME=checkstyle.xml
+
 VALIDATE_ANSIBLE=false
 VALIDATE_ARM=false
 # VALIDATE_BASH=false


### PR DESCRIPTION
Previously, `checkstyle.xml` was not actually used