### PR TITLE
chore: fix typo in super-linter.yaml

### DIFF
--- a/workflow-templates/super-linter.yaml
+++ b/workflow-templates/super-linter.yaml
@@ -39,7 +39,7 @@ jobs:
         repository: netcracker/.github
         sparse-checkout: |
           config/linters
-    - name: "Upload the common linters configsuration"
+    - name: "Upload the common linters configuration"
       uses: actions/upload-artifact@v4
       with:
         name: linter-config


### PR DESCRIPTION
fix typo issue in super-linter.yaml (name of step 'configsuration')