### PR TITLE
fix: Remove types and update link-checker workflow to use actions/checkout@v5

### DIFF
--- a/workflow-templates/link-checker.yaml
+++ b/workflow-templates/link-checker.yaml
@@ -7,15 +7,13 @@ on:
   workflow_dispatch: null
   pull_request:
     branches: [main]
-    types:
-      [opened, reopened, synchronize]
-permissions:
-  contents: read
+  permissions:
+    contents: read
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore lychee cache
         uses: actions/cache@v4


### PR DESCRIPTION
Remove types from pull_request and 
Upgrade the link-checker workflow to utilize actions/checkout@v5 and streamline permissions settings.