### PR TITLE
chore: Remove draft check from CLA Assistant job

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   CLAAssistant:
-    if: github.event.pull_request.draft == false
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Eliminate the draft check condition from the CLA Assistant job to allow it to run regardless of the pull request's draft status.