### PR TITLE
feat(ci): Add maven-release-v2 workflow for QIP repos

### DIFF
--- a/.github/broadcast-files-config.yaml
+++ b/.github/broadcast-files-config.yaml
@@ -79,3 +79,11 @@ cla_workflow:
   commit_message: |
     chore(ci): update of CLA workflow
     CLA will not executed on PRs in draft state
+maven_release_workflow_v2:
+  patterns_to_include: workflow-templates/maven-release-v2.yaml
+  destination: .github/workflows
+  bot_branch_name: broadcast-maven-release-v2
+  commit_message: |
+    feat(ci): Broadcast maven-release-v2 workflow to QIP repos
+    Related issue: https://github.com/Netcracker/.github/issues/136
+


### PR DESCRIPTION
Introduce a new CI workflow for Maven releases in QIP repositories, enhancing the automation of the release process. This change addresses issue #136.