### PR TITLE
fix(workflow): standardize input descriptions and update permissions in maven-release-v2 workflow

### DIFF
--- a/workflow-templates/maven-release-v2.yaml
+++ b/workflow-templates/maven-release-v2.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: "Build and Publish current SNAPSHOT (dry run)"
         uses: netcracker/qubership-workflow-hub/actions/maven-release@de43c4115d6d3b1547060e7ef2a137aa9ab60fc1 #v1.0.5


### PR DESCRIPTION
Standardize the input descriptions for clarity and update permissions to enhance security in the maven-release-v2 workflow.