### PR TITLE
fix(workflows): isolate Docker publication from bot builds

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 #v8.6.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dev-docker-build-multiple-images.yml
+++ b/workflow-templates/dev-docker-build-multiple-images.yml
@@ -50,17 +50,39 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref_type == 'branch' && github.ref_name || github.sha }}
+  cancel-in-progress: false
+
 env:
   CONFIG_FILE: '.qubership/docker.cfg'
+  DRY_RUN: >-
+    ${{
+      inputs.dry-run ||
+      github.event.sender.type == 'Bot' ||
+      github.triggering_actor != github.actor ||
+      (github.event_name == 'pull_request' &&
+        (github.event.pull_request.head.repo.full_name != github.repository ||
+          github.event.pull_request.user.type == 'Bot'))
+    }}
 
 jobs:
   load-config:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
-      packages: read
+      contents: read
     outputs:
+      dry-run: ${{ steps.policy.outputs.dry-run }}
       packages: ${{ steps.config.outputs.config }}
+      tags: ${{ steps.metadata.outputs.result }}
     steps:
+      - name: "Export publish policy"
+        id: policy
+        env:
+          VALUE: ${{ env.DRY_RUN }}
+        run: printf 'dry-run=%s\n' "$VALUE" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -72,55 +94,65 @@ jobs:
         with:
           file-path: "${{ env.CONFIG_FILE }}"
 
-  docker-build:
-    name: "Build and Publish Docker Image"
-    needs: load-config
-    permissions:
-      packages: write
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        component: ${{ fromJson(needs.load-config.outputs.packages) }}
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
       - name: "Create name"
         uses: netcracker/qubership-workflow-hub/actions/metadata-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: metadata
         with:
           default-template: "{{ref-name}}"
-          extra-tags: ${{ github.event.inputs.tags || '' }}
-          replace-symbol: ${{ github.event.inputs.replace-symbol || '_'}}
-
-      - name: "Prepare tags"
-        id: prepare_tags
-        run: |
-          BASE_TAG="${{ steps.metadata.outputs.result }}"
-          EXTRA_TAG="${{ github.event.inputs.tags }}"
-          if [ -n "$EXTRA_TAG" ]; then
-            TAGS="${BASE_TAG}, ${EXTRA_TAG}"
-          else
-            TAGS="${BASE_TAG}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          extra-tags: ${{ inputs.tags || '' }}
+          replace-symbol: ${{ inputs.replace-symbol || '_' }}
 
       - name: "Summary step"
+        env:
+          METADATA: ${{ steps.metadata.outputs.result }}
+          TAGS: ${{ steps.metadata.outputs.result }}
         run: |
-          echo "**Metadata:** ${{ steps.metadata.outputs.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.prepare_tags.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          printf '**Metadata:** %s\n' "$METADATA" >> "$GITHUB_STEP_SUMMARY"
+          printf '**Tags:** %s\n' "$TAGS" >> "$GITHUB_STEP_SUMMARY"
 
+  docker-build:
+    name: "Docker Image Dry Run"
+    if: needs.load-config.outputs.dry-run == 'true'
+    needs: load-config
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: true
+      matrix:
+        component: ${{ fromJson(needs.load-config.outputs.packages) }}
+    steps:
+      - name: "Build Docker Image"
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        with:
+          component: ${{ toJson(matrix.component) }}
+          platforms: ${{ matrix.component.platforms }}
+          tags: ${{ needs.load-config.outputs.tags }}
+          dry-run: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-publish:
+    name: "Docker Image Publish"
+    if: needs.load-config.outputs.dry-run == 'false' && github.triggering_actor == github.actor
+    needs: load-config
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: true
+      matrix:
+        component: ${{ fromJson(needs.load-config.outputs.packages) }}
+    steps:
       - name: "Build and Publish Docker Image"
         uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
         with:
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ matrix.component.platforms }}
-          checkout: "false"
-          tags: ${{ steps.prepare_tags.outputs.tags }}
-          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+          tags: ${{ needs.load-config.outputs.tags }}
+          dry-run: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dev-docker-build-multiple-images.yml
+++ b/workflow-templates/dev-docker-build-multiple-images.yml
@@ -27,26 +27,26 @@ on:
         description: "Symbol to replace in tags"
   push:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
   pull_request:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
 permissions:
   contents: read
 
@@ -89,7 +89,7 @@ jobs:
           persist-credentials: false
 
       - name: Get Configuration File
-        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: config
         with:
           file-path: "${{ env.CONFIG_FILE }}"
@@ -124,7 +124,7 @@ jobs:
         component: ${{ fromJson(needs.load-config.outputs.packages) }}
     steps:
       - name: "Build Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ matrix.component.platforms }}
@@ -148,7 +148,7 @@ jobs:
         component: ${{ fromJson(needs.load-config.outputs.packages) }}
     steps:
       - name: "Build and Publish Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ matrix.component.platforms }}

--- a/workflow-templates/dev-docker-build-selective.yml
+++ b/workflow-templates/dev-docker-build-selective.yml
@@ -122,13 +122,13 @@ jobs:
           fi
 
       - name: Get Configuration File
-        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: config
         with:
           file-path: "updated_config.json"
 
       - name: Create tags for images
-        uses: netcracker/qubership-workflow-hub/actions/metadata-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/metadata-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: meta
         with:
           default-template: "{{ref-name}}"
@@ -149,7 +149,7 @@ jobs:
         component: ${{ fromJson(needs.prepare.outputs.packages) }}
     steps:
       - name: Docker
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           ref: ${{ github.ref }}
           dry-run: "true"
@@ -175,7 +175,7 @@ jobs:
         component: ${{ fromJson(needs.prepare.outputs.packages) }}
     steps:
       - name: Docker
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           ref: ${{ github.ref }}
           dry-run: "false"

--- a/workflow-templates/dev-docker-build-selective.yml
+++ b/workflow-templates/dev-docker-build-selective.yml
@@ -52,23 +52,40 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.ref_type == 'branch' && format('build-branch-{0}', github.ref_name) || format('build-{0}', github.sha) }}
-  cancel-in-progress: true
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref_type == 'branch' && github.ref_name || github.sha }}
+  cancel-in-progress: false
 
 env:
   CONFIG_FILE: '.qubership/docker.cfg'
+  DRY_RUN: >-
+    ${{
+      inputs.dry-run ||
+      github.event.sender.type == 'Bot' ||
+      github.triggering_actor != github.actor ||
+      (github.event_name == 'pull_request' &&
+        (github.event.pull_request.head.repo.full_name != github.repository ||
+          github.event.pull_request.user.type == 'Bot'))
+    }}
 
 jobs:
   prepare:
     name: "Prepare Images and Metadata"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
+      dry-run: ${{ steps.policy.outputs.dry-run }}
       packages: ${{ steps.config.outputs.config }}
       tags: "${{ steps.meta.outputs.result }}"
     steps:
+      - name: "Export publish policy"
+        id: policy
+        env:
+          VALUE: ${{ env.DRY_RUN }}
+        run: printf 'dry-run=%s\n' "$VALUE" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Changed Files
@@ -81,27 +98,26 @@ jobs:
 
       - name: Load Components and Platforms
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            components=$(jq -c '.components' ${CONFIG_FILE})
-          fi
+          cp "$CONFIG_FILE" updated_config.json
+
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]]; then
             all_changed_files=$(jq -c '.' .github/outputs/all_changed_files.json)
             if [ "$all_changed_files" != "null" ]; then
-                components_file="${CONFIG_FILE}"
-                files_file=".github/outputs/all_changed_files.json"
+              components_file="${CONFIG_FILE}"
+              files_file=".github/outputs/all_changed_files.json"
 
-                jq -c --argjson files "$(cat "$files_file")" '
-                  .components |
-                  [ .[] | select(
-                      . as $component |
-                      any($files[];
-                        [ $component.changeset[] as $ch | startswith($ch) ] | any
-                      )
+              jq -c --argjson files "$(cat "$files_file")" '
+                .components |
+                [ .[] | select(
+                    . as $component |
+                    any($files[];
+                      [ $component.changeset[] as $ch | startswith($ch) ] | any
                     )
-                  ]
-                ' "$components_file" > /tmp/filtered_components.json
+                  )
+                ]
+              ' "$components_file" > /tmp/filtered_components.json
 
-                jq '.components = input' ${CONFIG_FILE} /tmp/filtered_components.json > updated_config.json
+              jq '.components = input' "$CONFIG_FILE" /tmp/filtered_components.json > updated_config.json
             fi
           fi
 
@@ -120,9 +136,36 @@ jobs:
           replace-symbol: ${{ github.event.inputs.replace-symbol || '_'}}
 
   build:
-    name: ${{ matrix.component.name }} Image Build
+    name: ${{ matrix.component.name }} Image Dry Run
+    if: needs.prepare.outputs.dry-run == 'true'
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJson(needs.prepare.outputs.packages) }}
+    steps:
+      - name: Docker
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        with:
+          ref: ${{ github.ref }}
+          dry-run: "true"
+          download-artifact: false
+          component: ${{ toJson(matrix.component) }}
+          platforms: ${{ matrix.component.platforms }}
+          tags: ${{ needs.prepare.outputs.tags }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: ${{ matrix.component.name }} Image Publish
+    if: needs.prepare.outputs.dry-run == 'false' && github.triggering_actor == github.actor
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -135,7 +178,7 @@ jobs:
         uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
         with:
           ref: ${{ github.ref }}
-          dry-run: ${{ github.event.inputs.dry-run || github.event_name == 'pull_request' }}
+          dry-run: "false"
           download-artifact: false
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ matrix.component.platforms }}

--- a/workflow-templates/dev-docker-build-single-image.yml
+++ b/workflow-templates/dev-docker-build-single-image.yml
@@ -48,53 +48,88 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref_type == 'branch' && github.ref_name || github.sha }}
+  cancel-in-progress: false
+
 env:
+  DRY_RUN: >-
+    ${{
+      inputs.dry-run ||
+      github.event.sender.type == 'Bot' ||
+      github.triggering_actor != github.actor ||
+      (github.event_name == 'pull_request' &&
+        (github.event.pull_request.head.repo.full_name != github.repository ||
+          github.event.pull_request.user.type == 'Bot'))
+    }}
   PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
-  docker-build:
-    name: "Build and Publish Docker Image"
+  prepare:
+    name: "Prepare Docker Image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
-      packages: write
       contents: read
     outputs:
-      metadata: "${{ steps.metadata.outputs.result }}"
-      tags: "${{ steps.prepare_tags.outputs.tags }}"
-    runs-on: ubuntu-latest
+      dry-run: ${{ steps.policy.outputs.dry-run }}
+      tags: ${{ steps.metadata.outputs.result }}
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
+      - name: "Export publish policy"
+        id: policy
+        env:
+          VALUE: ${{ env.DRY_RUN }}
+        run: printf 'dry-run=%s\n' "$VALUE" >> "$GITHUB_OUTPUT"
 
       - name: "Create name"
         uses: netcracker/qubership-workflow-hub/actions/metadata-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: metadata
-
-      - name: "Prepare tags"
-        id: prepare_tags
-        run: |
-          BASE_TAG="${{ steps.metadata.outputs.result }}"
-          EXTRA_TAG="${{ github.event.inputs.tags }}"
-          if [ -n "$EXTRA_TAG" ]; then
-            TAGS="${BASE_TAG}, ${EXTRA_TAG}"
-          else
-            TAGS="${BASE_TAG}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+        with:
+          extra-tags: ${{ inputs.tags || '' }}
 
       - name: "Summary step"
+        env:
+          METADATA: ${{ steps.metadata.outputs.result }}
+          TAGS: ${{ steps.metadata.outputs.result }}
         run: |
-          echo "**Metadata:** ${{ steps.metadata.outputs.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.prepare_tags.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          printf '**Metadata:** %s\n' "$METADATA" >> "$GITHUB_STEP_SUMMARY"
+          printf '**Tags:** %s\n' "$TAGS" >> "$GITHUB_STEP_SUMMARY"
 
+  docker-build:
+    name: "Docker Image Dry Run"
+    if: needs.prepare.outputs.dry-run == 'true'
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: "Build Docker Image"
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        with:
+          custom-image-name: ${{ inputs.custom-image-name || '' }}
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ needs.prepare.outputs.tags }}
+          dry-run: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-publish:
+    name: "Docker Image Publish"
+    if: needs.prepare.outputs.dry-run == 'false' && github.triggering_actor == github.actor
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
       - name: "Build and Publish Docker Image"
         uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
         with:
-          custom-image-name: ${{ github.event.inputs.custom-image-name || '' }}
+          custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}
-          checkout: "false"
-          tags: ${{ steps.prepare_tags.outputs.tags }}
-          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+          tags: ${{ needs.prepare.outputs.tags }}
+          dry-run: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dev-docker-build-single-image.yml
+++ b/workflow-templates/dev-docker-build-single-image.yml
@@ -25,26 +25,26 @@ on:
         default: false
   push:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
   pull_request:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
 permissions:
   contents: read
 
@@ -105,7 +105,7 @@ jobs:
       contents: read
     steps:
       - name: "Build Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}
@@ -125,7 +125,7 @@ jobs:
       packages: write
     steps:
       - name: "Build and Publish Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}

--- a/workflow-templates/dev-mvn-docker-build.yml
+++ b/workflow-templates/dev-mvn-docker-build.yml
@@ -30,26 +30,26 @@ on:
         default: false
   push:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
   pull_request:
     branches:
-    - '**'
+      - '**'
     paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'CODE-OF-CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'SECURITY.md'
 
 permissions:
   contents: read
@@ -93,7 +93,7 @@ jobs:
           persist-credentials: false
 
       - name: "Maven build artifact"
-        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           maven-command: "${{ env.DRY_RUN == 'true' && '--batch-mode clean install -Dgpg.skip=true' || inputs.maven-command || '--batch-mode clean install -Dgpg.skip=true' }}"
           java-version: ${{ inputs.java-version || '21' }}
@@ -125,7 +125,7 @@ jobs:
       contents: read
     steps:
       - name: "Build Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}
@@ -147,7 +147,7 @@ jobs:
       packages: write
     steps:
       - name: "Build and Publish Docker Image"
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         with:
           custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}

--- a/workflow-templates/dev-mvn-docker-build.yml
+++ b/workflow-templates/dev-mvn-docker-build.yml
@@ -54,14 +54,39 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref_type == 'branch' && github.ref_name || github.sha }}
+  cancel-in-progress: false
+
+env:
+  DRY_RUN: >-
+    ${{
+      inputs.dry-run ||
+      github.event.sender.type == 'Bot' ||
+      github.triggering_actor != github.actor ||
+      (github.event_name == 'pull_request' &&
+        (github.event.pull_request.head.repo.full_name != github.repository ||
+          github.event.pull_request.user.type == 'Bot'))
+    }}
+  PLATFORMS: linux/amd64,linux/arm64
+
 jobs:
-  dev-build:
-    name: "Maven Build and Docker Image Publish"
+  maven-build:
+    name: "Maven Build"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
-      packages: write
+    outputs:
+      dry-run: ${{ steps.policy.outputs.dry-run }}
+      tags: ${{ steps.metadata.outputs.result }}
     steps:
+      - name: "Export publish policy"
+        id: policy
+        env:
+          VALUE: ${{ env.DRY_RUN }}
+        run: printf 'dry-run=%s\n' "$VALUE" >> "$GITHUB_OUTPUT"
+
       - name: "Checkout code"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -70,37 +95,65 @@ jobs:
       - name: "Maven build artifact"
         uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
         with:
-          maven-command: "${{ github.event.inputs.maven-command || '--batch-mode clean install -Dgpg.skip=true' }}"
-          java-version: ${{ github.event.inputs.java-version || '21' }}
+          maven-command: "${{ env.DRY_RUN == 'true' && '--batch-mode clean install -Dgpg.skip=true' || inputs.maven-command || '--batch-mode clean install -Dgpg.skip=true' }}"
+          java-version: ${{ inputs.java-version || '21' }}
+          upload-artifact: "true"
+          artifact-id: maven-build-output
+          maven-token: ${{ github.token }}
 
       - name: "Generate metadata"
         uses: netcracker/qubership-workflow-hub/actions/metadata-action@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0
         id: metadata
-
-      - name: "Prepare tags"
-        id: prepare_tags
-        run: |
-          BASE_TAG="${{ steps.metadata.outputs.result }}"
-          EXTRA_TAG="${{ github.event.inputs.tags }}"
-          if [ -n "$EXTRA_TAG" ]; then
-            TAGS="${BASE_TAG}, ${EXTRA_TAG}"
-          else
-            TAGS="${BASE_TAG}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+        with:
+          extra-tags: ${{ inputs.tags || '' }}
 
       - name: "Summary step"
+        env:
+          METADATA: ${{ steps.metadata.outputs.result }}
+          TAGS: ${{ steps.metadata.outputs.result }}
         run: |
-          echo "**Metadata:** ${{ steps.metadata.outputs.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.prepare_tags.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          printf '**Metadata:** %s\n' "$METADATA" >> "$GITHUB_STEP_SUMMARY"
+          printf '**Tags:** %s\n' "$TAGS" >> "$GITHUB_STEP_SUMMARY"
 
+  docker-build:
+    name: "Docker Image Dry Run"
+    if: needs.maven-build.outputs.dry-run == 'true'
+    needs: maven-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: "Build Docker Image"
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
+        with:
+          custom-image-name: ${{ inputs.custom-image-name || '' }}
+          platforms: ${{ env.PLATFORMS }}
+          download-artifact: "true"
+          download-artifact-name: maven-build-output
+          tags: ${{ needs.maven-build.outputs.tags }}
+          dry-run: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-publish:
+    name: "Docker Image Publish"
+    if: needs.maven-build.outputs.dry-run == 'false' && github.triggering_actor == github.actor
+    needs: maven-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
       - name: "Build and Publish Docker Image"
         uses: netcracker/qubership-workflow-hub/actions/docker-action@cabbb90e9471163cfac84bd50ff0296b2803b44c #v2.3.0
         with:
-          custom-image-name: ${{ github.event.inputs.custom-image-name || '' }}
+          custom-image-name: ${{ inputs.custom-image-name || '' }}
           platforms: ${{ env.PLATFORMS }}
-          checkout: "false"
-          tags: ${{ steps.prepare_tags.outputs.tags }}
-          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+          download-artifact: "true"
+          download-artifact-name: maven-build-output
+          tags: ${{ needs.maven-build.outputs.tags }}
+          dry-run: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/renovate-config-lint.yaml
+++ b/workflow-templates/renovate-config-lint.yaml
@@ -1,7 +1,7 @@
 name: Validate Renovate Config
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     paths:
       - renovate.json

--- a/workflow-templates/renovate-config-lint.yaml
+++ b/workflow-templates/renovate-config-lint.yaml
@@ -1,24 +1,60 @@
 name: Validate Renovate Config
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - renovate.json
+      - renovate.jsonc
+      - renovate.json5
+      - .github/renovate.json
+      - .github/renovate.jsonc
+      - .github/renovate.json5
+      - .gitlab/renovate.json
+      - .gitlab/renovate.jsonc
+      - .gitlab/renovate.json5
+      - .renovaterc
+      - .renovaterc.json
+      - .renovaterc.jsonc
+      - .renovaterc.json5
+      - package.json
   pull_request:
     paths:
       - renovate.json
+      - renovate.jsonc
+      - renovate.json5
+      - .github/renovate.json
+      - .github/renovate.jsonc
+      - .github/renovate.json5
+      - .gitlab/renovate.json
+      - .gitlab/renovate.jsonc
+      - .gitlab/renovate.json5
+      - .renovaterc
+      - .renovaterc.json
+      - .renovaterc.jsonc
+      - .renovaterc.json5
+      - package.json
 
-permissions: read-all
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-config-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-renovate-config:
-    name: Validate renovate.json
+    name: Validate Renovate configuration
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json
+      - name: Validate Renovate configuration
+        run: >-
+          docker run --rm -v "$PWD":/work -w /work
+          renovate/renovate:43.256.0@sha256:6658b0d04d9f09550a9802181a4cc21fd8ba5d83238018f710e847466f6a488c
+          renovate-config-validator --strict


### PR DESCRIPTION
## Summary

- isolate Docker publication from bot, fork, and explicit dry-run builds
- keep `packages: write` only in a fail-closed publish job
- make publication rerun-safe and prevent in-progress publish cancellation
- validate all supported Renovate configuration locations in strict mode
- use a pinned Renovate validator image
- switch the repository Super-Linter workflow to the slim variant
- fix selective Docker configuration handling and metadata tag construction

## Publication policy

- Human same-repository runs may publish development images.
- GitHub App and other `Bot` events, bot-authored PRs, fork PRs, and different-actor reruns use read-only dry-run jobs.
- Publish jobs require the policy output to be exactly `false` and require `github.triggering_actor == github.actor`.
- Publish jobs are not cancelled by later runs, avoiding partial image publication.

## Verification

- `actionlint`
- `zizmor --offline --strict-collection`
- `act -l` for all changed workflows
- Renovate validator with a pinned image and `--strict`
- event policy matrix covering human, bot, fork, and rerun cases
- selective Docker configuration fixture
- `git diff --check`

The direct push to `Netcracker/.github` was not available, so this PR is opened from `IldarMinaev/.github`.
