### PR TITLE
fix(ci): validate shared Renovate presets

### DIFF
--- a/workflow-templates/renovate-config-lint.yaml
+++ b/workflow-templates/renovate-config-lint.yaml
@@ -4,16 +4,21 @@ on:
   push:
     paths:
       - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
   pull_request:
     paths:
       - renovate.json
-
-permissions: read-all
+      - .github/workflows/renovate-config-lint.yaml
 
 jobs:
   validate-renovate-config:
     name: Validate renovate.json
     runs-on: ubuntu-latest
+    container:
+      image: renovate/renovate:43.285.4@sha256:bd7d8f646bf9d22aea995eaad06ec26c3f4fd4efbc36826024f5653006c9e7b1
+      options: --user 0
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -21,4 +26,24 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json
+        run: renovate-config-validator --strict --no-global renovate.json
+
+      - name: Resolve shared Renovate presets
+        shell: bash
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          LOG_FORMAT: json
+          LOG_LEVEL: warn
+        run: |
+          set -o pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          validation_filter='fromjson? | select(.err.validationError? or .msg == "Repository has invalid config")'
+
+          renovate --platform=local --dry-run=extract 2>&1 | tee "$log_file"
+
+          if jq -R -e "$validation_filter" "$log_file" >/dev/null; then
+            echo "::error::Renovate could not resolve the repository configuration"
+            jq -R -r "$validation_filter | .err.validationError // .msg" "$log_file"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Run the strict Renovate validator in a digest-pinned Renovate container.
- Run the container as root so GitHub Actions can write its runner command files during checkout.
- Resolve shared presets with a local Renovate dry run.
- Run when either `renovate.json` or the generated workflow changes.
- Limit the job token to read-only repository contents.

## Why

Schema validation does not resolve remote presets. A missing or invalid shared preset can therefore pass the current check and fail later in Mend Renovate. The Renovate image runs as a non-root user by default, which cannot write the command files mounted by the GitHub-hosted runner.

## Validation

- `actionlint workflow-templates/renovate-config-lint.yaml`
- Strict validation and shared-preset resolution were exercised with the pinned Renovate image.
