### PR TITLE
feat(workflows): add Renovate health opt-out

### DIFF
--- a/docs/workflows/renovate-config-lint.md
+++ b/docs/workflows/renovate-config-lint.md
@@ -2,14 +2,20 @@
 
 ## Overview
 
-This workflow validates `renovate.json`, resolves shared presets, checks dependency lookups, and reports Renovate health failures as a GitHub issue.
+This workflow validates `renovate.json`, resolves shared presets, checks dependency lookups, and reports Renovate health
+failures as a GitHub issue.
 
 ## Requirements
 
 - Add `renovate.json` to the repository root.
-- Enable the Mend Renovate Community app for the repository.
-- Enable the Renovate Dependency Dashboard with its default `Dependency Dashboard` title.
-- Enable GitHub Issues and allow GitHub Actions to create issues with the repository `GITHUB_TOKEN`.
+- For repositories that run Renovate, enable the Mend Renovate Community app and the Dependency Dashboard with its
+  default `Dependency Dashboard` title.
+- Enable GitHub Issues and allow GitHub Actions to create issues with the repository `GITHUB_TOKEN` for Dashboard and
+  incident reporting. The workflow provides limited reporting in its run summary when Issues are disabled.
+
+If a repository intentionally does not run Renovate, set the Actions variable `RENOVATE_HEALTH_CHECK` to `false`.
+Dependency lookup and health monitoring stop, while configuration validation continues on changes and on the weekly
+schedule. Close any existing `Renovate health check failed` issue manually after setting the variable.
 
 ## Triggers
 
@@ -21,21 +27,31 @@ This workflow validates `renovate.json`, resolves shared presets, checks depende
 
 ### Validate Renovate configuration
 
-The validation job runs the strict Renovate configuration validator and resolves shared presets. It reports invalid configuration, unavailable presets, GitHub API rate limits, and nonzero Renovate exit codes.
+The validation job runs the strict Renovate configuration validator and resolves shared presets. It reports invalid
+configuration, unavailable presets, GitHub API rate limits, and nonzero Renovate exit codes.
 
 ### Look up dependencies
 
-The lookup job runs `renovate --platform=local --dry-run=lookup`. It retries lookup-only failures once with a fresh cache and reports persistent lookup failures, rate limits, error records, and command failures.
+The lookup job runs `renovate --platform=local --dry-run=lookup`. It retries lookup-only failures once with a fresh
+cache and reports persistent lookup failures, rate limits, error records, and command failures.
 
 ### Monitor Renovate health
 
-The monitor checks the hosted Dependency Dashboard for repository problems, errored updates, and dependency lookup failures. It creates one `Renovate health check failed` issue with links to the failed health-check run and the Dependency Dashboard.
+The monitor checks the hosted Dependency Dashboard for repository problems, errored updates, and dependency lookup
+failures. It creates one `Renovate health check failed` issue with links to the failed health-check run and the
+Dependency Dashboard.
 
-Repeated failures add a comment with the latest run instead of creating another issue. A successful check adds a recovery comment and closes the managed issue automatically.
+If GitHub Issues are disabled, the workflow skips Dashboard and incident-issue operations. Validation and dependency
+lookup still run, and their failures remain visible in the workflow run.
+
+Repeated failures add a comment with the latest run instead of creating another issue. A successful check adds a
+recovery comment and closes the managed issue automatically.
 
 ## Schedule
 
-Replace the example cron value with one stable Monday slot between 06:00 and 10:59 UTC. To derive the slot, hash `owner/repository` with SHA-256, convert the first eight hexadecimal characters to an integer, and take the result modulo 300. The quotient divided by 60 selects the hour after 06:00, and the remainder selects the minute.
+Replace the example cron value with one stable Monday slot between 06:00 and 10:59 UTC. To derive the slot, hash
+`owner/repository` with SHA-256, convert the first eight hexadecimal characters to an integer, and take the result
+modulo 300. The quotient divided by 60 selects the hour after 06:00, and the remainder selects the minute.
 
 When assigning schedules to multiple repositories, move a colliding result to the next free minute in the window.
 

--- a/workflow-templates/renovate-config-lint.yaml
+++ b/workflow-templates/renovate-config-lint.yaml
@@ -90,8 +90,13 @@ jobs:
           fi
 
   lookup-renovate-dependencies:
+    # Set the Actions variable RENOVATE_HEALTH_CHECK to false when this
+    # repository intentionally does not run Renovate. Validation remains active
+    # so local and inherited configuration errors are still reported.
     name: Look up Renovate dependencies
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && vars.RENOVATE_HEALTH_CHECK != 'false'
     runs-on: ubuntu-latest
     outputs:
       reason: ${{ steps.lookup.outputs.reason }}
@@ -236,7 +241,10 @@ jobs:
 
   monitor-renovate:
     name: Monitor Renovate health
-    if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: >-
+      ${{ !cancelled()
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && vars.RENOVATE_HEALTH_CHECK != 'false' }}
     needs:
       - validate-renovate-config
       - lookup-renovate-dependencies
@@ -264,27 +272,34 @@ jobs:
           health_title='Renovate health check failed'
           health_marker='<!-- renovate-health-check -->'
           run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          opt_out_hint="If this repository is not meant to run Renovate, set the Actions variable \`RENOVATE_HEALTH_CHECK\` to \`false\` to stop the health check. Config validation continues on changes and on the weekly schedule."
+          opt_out_hint_issue="$opt_out_hint Close this issue manually after setting the variable because only a passing check closes it automatically."
           dashboard_url=''
           reasons=()
+          notes=()
 
-          # The server-side author filter uses the raw renovate[bot] login,
-          # while the returned JSON uses app/renovate. The shared presets use
-          # Renovate's default title. Update all three values together.
-          dashboard_issues_json="$(gh issue list \
-            --state open \
-            --author 'renovate[bot]' \
-            --limit 1000 \
-            --json author,body,number,title,url)"
+          issues_enabled="$(gh api "repos/$GH_REPO" --jq '.has_issues')"
+          dashboard_json=''
+          if [[ "$issues_enabled" == 'true' ]]; then
+            # The server-side author filter uses the raw renovate[bot] login,
+            # while the returned JSON uses app/renovate. The shared presets use
+            # Renovate's default title. Update all three values together.
+            dashboard_issues_json="$(gh issue list \
+              --state open \
+              --author 'renovate[bot]' \
+              --limit 1000 \
+              --json author,body,number,title,url)"
 
-          dashboard_json="$(jq -c \
-            --arg author 'app/renovate' \
-            --arg title "$dashboard_title" \
-            '[.[] | select(.title == $title and .author.login == $author)] | first // empty' \
-            <<< "$dashboard_issues_json")"
-
-          if [[ -z "$dashboard_json" ]]; then
-            reasons+=('Renovate Dependency Dashboard was not found')
+            dashboard_json="$(jq -c \
+              --arg author 'app/renovate' \
+              --arg title "$dashboard_title" \
+              '[.[] | select(.title == $title and .author.login == $author)] | first // empty' \
+              <<< "$dashboard_issues_json")"
           else
+            notes+=("Issues are disabled, so Renovate cannot publish a Dependency Dashboard and this workflow cannot file a health issue. Dashboard inspection is skipped; validation and lookup results are still reported. $opt_out_hint")
+          fi
+
+          if [[ -n "$dashboard_json" ]]; then
             dashboard_body="$(jq -r '.body' <<< "$dashboard_json")"
             dashboard_url="$(jq -r '.url' <<< "$dashboard_json")"
 
@@ -297,6 +312,8 @@ jobs:
             if grep -q 'Renovate failed to look up' <<< "$dashboard_body"; then
               reasons+=('Dependency Dashboard reports lookup failures')
             fi
+          elif [[ "$issues_enabled" == 'true' ]]; then
+            reasons+=('Renovate Dependency Dashboard was not found')
           fi
 
           if [[ "$VALIDATION_RESULT" != 'success' ]]; then
@@ -314,17 +331,20 @@ jobs:
             fi
           fi
 
-          health_issues_json="$(gh issue list \
-            --state open \
-            --label "$health_label" \
-            --limit 1000 \
-            --json body,number,title,url)"
+          health_number=''
+          if [[ "$issues_enabled" == 'true' ]]; then
+            health_issues_json="$(gh issue list \
+              --state open \
+              --label "$health_label" \
+              --limit 1000 \
+              --json body,number,title,url)"
 
-          health_number="$(jq -r \
-            --arg marker "$health_marker" \
-            --arg title "$health_title" \
-            '[.[] | select(.title == $title and ((.body // "") | contains($marker)))] | first | .number // empty' \
-            <<< "$health_issues_json")"
+            health_number="$(jq -r \
+              --arg marker "$health_marker" \
+              --arg title "$health_title" \
+              '[.[] | select(.title == $title and ((.body // "") | contains($marker)))] | first | .number // empty' \
+              <<< "$health_issues_json")"
+          fi
 
           if ((${#reasons[@]} == 0)); then
             {
@@ -332,15 +352,28 @@ jobs:
               echo
               echo 'Healthy'
               echo
-              echo "- [Renovate Dependency Dashboard]($dashboard_url)"
+              if ((${#notes[@]} != 0)); then
+                printf -- '- %s\n' "${notes[@]}"
+              fi
+              if [[ -n "$dashboard_url" ]]; then
+                echo "- [Renovate Dependency Dashboard]($dashboard_url)"
+              fi
               echo "- [Renovate health-check run]($run_url)"
             } >> "$GITHUB_STEP_SUMMARY"
 
             if [[ -n "$health_number" ]]; then
               recovery_file="$(mktemp)"
               trap 'rm -f "$recovery_file"' EXIT
-              printf 'The Renovate health check passed. This issue is closing automatically.\n\n### Details\n\n- [Successful Renovate health-check run](%s)\n- [Renovate Dependency Dashboard](%s)\n' \
-                "$run_url" "$dashboard_url" > "$recovery_file"
+              {
+                echo 'The Renovate health check passed. This issue is closing automatically.'
+                echo
+                echo '### Details'
+                echo
+                echo "- [Successful Renovate health-check run]($run_url)"
+                if [[ -n "$dashboard_url" ]]; then
+                  echo "- [Renovate Dependency Dashboard]($dashboard_url)"
+                fi
+              } > "$recovery_file"
               gh issue comment "$health_number" --body-file "$recovery_file"
               gh issue close "$health_number" --reason completed
             fi
@@ -365,6 +398,8 @@ jobs:
               fi
               echo
               echo 'This issue remains open and will close automatically after a successful check.'
+              echo
+              echo "$opt_out_hint_issue"
             } > "$report_file"
           else
             {
@@ -376,6 +411,8 @@ jobs:
               printf -- '- %s\n' "${reasons[@]}"
               echo
               echo 'Review the details below, fix the listed problems, and rerun the health check. This issue updates after repeated failures and closes automatically after a successful check.'
+              echo
+              echo "$opt_out_hint_issue"
               echo
               echo '### Details'
               echo
@@ -393,20 +430,26 @@ jobs:
             echo
             printf -- '- %s\n' "${reasons[@]}"
             echo
+            if ((${#notes[@]} != 0)); then
+              printf -- '- %s\n' "${notes[@]}"
+              echo
+            fi
             if [[ -n "$dashboard_url" ]]; then
               echo "- [Renovate Dependency Dashboard]($dashboard_url)"
             fi
             echo "- [Renovate health-check run]($run_url)"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ -n "$health_number" ]]; then
-            gh issue comment "$health_number" --body-file "$report_file"
-          else
-            gh label create "$health_label" \
-              --color D73A4A \
-              --description 'Automated Renovate health incident' \
-              --force
-            gh issue create --title "$health_title" --label "$health_label" --body-file "$report_file"
+          if [[ "$issues_enabled" == 'true' ]]; then
+            if [[ -n "$health_number" ]]; then
+              gh issue comment "$health_number" --body-file "$report_file"
+            else
+              gh label create "$health_label" \
+                --color D73A4A \
+                --description 'Automated Renovate health incident' \
+                --force
+              gh issue create --title "$health_title" --label "$health_label" --body-file "$report_file"
+            fi
           fi
 
           echo '::error::Renovate health check failed'


### PR DESCRIPTION
## Why

Repositories that intentionally do not run Renovate need an explicit way to disable dependency lookup and health monitoring. Missing Dependency Dashboards must remain an error for every repository where monitoring is enabled.

## What

- Add the `RENOVATE_HEALTH_CHECK=false` repository variable as an explicit opt-out.
- Keep Renovate configuration validation active after opt-out.
- Handle repositories with GitHub Issues disabled without failing issue operations.
- Treat a missing Dependency Dashboard as unhealthy when monitoring is enabled.
- Add user documentation.
- Keep the shared example schedule unchanged.

This behavior was tested in [Netcracker/qubership-ai-packages#72](https://github.com/Netcracker/qubership-ai-packages/pull/72).

## How to verify

- Run `actionlint workflow-templates/renovate-config-lint.yaml .github/workflows/super-linter.yaml`.
- Run Markdownlint and ShellCheck.

