### PR TITLE
fix(workflows): ignore benign Renovate health notices

### DIFF
--- a/docs/workflows/renovate-config-lint.md
+++ b/docs/workflows/renovate-config-lint.md
@@ -41,6 +41,11 @@ The monitor checks the hosted Dependency Dashboard for repository problems, erro
 failures. It creates one `Renovate health check failed` issue with links to the failed health-check run and the
 Dependency Dashboard.
 
+The monitor ignores only the two standard `minimumReleaseAgeBehaviour=timestamp-optional` notices that say missing
+release timestamps for releases or upgrades are allowed to proceed. When these are the only repository problems, the
+workflow summary reports `Dependency Dashboard only reports expected timestamp-optional notices`. Any other repository
+problem remains actionable.
+
 If GitHub Issues are disabled, the workflow skips Dashboard and incident-issue operations. Validation and dependency
 lookup still run, and their failures remain visible in the workflow run.
 
@@ -68,4 +73,6 @@ The schedule runs from the default branch. GitHub Actions can delay scheduled wo
 1. Change `renovate.json` in a pull request and confirm that `Validate renovate.json` succeeds.
 1. Run `Validate Renovate Config` manually from the Actions tab on the default branch.
 1. Confirm that validation, dependency lookup, and health monitoring succeed.
-1. Open the Dependency Dashboard and confirm that it has no repository problems or lookup failures.
+1. Open the Dependency Dashboard and confirm that it has no actionable repository problems or lookup failures. A
+  Dashboard containing only the two ignored `timestamp-optional` notices is healthy; confirm that the workflow summary
+  reports the expected-notices message.

--- a/workflow-templates/renovate-config-lint.yaml
+++ b/workflow-templates/renovate-config-lint.yaml
@@ -304,7 +304,40 @@ jobs:
             dashboard_url="$(jq -r '.url' <<< "$dashboard_json")"
 
             if grep -q '^## Repository Problems[[:space:]]*$' <<< "$dashboard_body"; then
-              reasons+=('Dependency Dashboard reports repository problems')
+              # Renovate records these notices as repository problems even though
+              # timestamp-optional explicitly allows the affected updates to proceed.
+              timestamp_optional_release_warning="⚠️ WARN: Some release(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information"
+              timestamp_optional_upgrade_warning="⚠️ WARN: Some upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information"
+              repository_problems_intro_pattern='^These problems occurred while renovating this repository\. \[View logs\]\(https://developer\.mend\.io/[^[:space:])]+\)\.$'
+              ignored_repository_problem_count=0
+              actionable_repository_problem_count=0
+
+              while IFS= read -r repository_problem_line; do
+                if [[ -z "$repository_problem_line" ]]; then
+                  continue
+                fi
+                if [[ "$repository_problem_line" == 'These problems occurred while renovating this repository.' ]]; then
+                  continue
+                fi
+                if [[ "$repository_problem_line" =~ $repository_problems_intro_pattern ]]; then
+                  continue
+                fi
+                if [[ "$repository_problem_line" == " - $timestamp_optional_release_warning" || "$repository_problem_line" == " - $timestamp_optional_upgrade_warning" ]]; then
+                  ignored_repository_problem_count=$((ignored_repository_problem_count + 1))
+                else
+                  actionable_repository_problem_count=$((actionable_repository_problem_count + 1))
+                fi
+              done < <(awk '
+                /^## Repository Problems[[:space:]]*$/ { in_repository_problems = 1; next }
+                in_repository_problems && /^## / { exit }
+                in_repository_problems { print }
+              ' <<< "$dashboard_body")
+
+              if [[ "$ignored_repository_problem_count" -eq 0 || "$actionable_repository_problem_count" -ne 0 ]]; then
+                reasons+=('Dependency Dashboard reports repository problems')
+              else
+                notes+=('Dependency Dashboard only reports expected timestamp-optional notices')
+              fi
             fi
             if grep -q '^## Errored[[:space:]]*$' <<< "$dashboard_body"; then
               reasons+=('Dependency Dashboard reports errored updates')


### PR DESCRIPTION
## Why

Renovate reports two `minimumReleaseAgeBehaviour=timestamp-optional` notices under `Repository Problems` even though the affected updates proceed. The health workflow treats the section heading alone as a failure and opens an incident for healthy repositories.

## What

- Ignore the two exact `timestamp-optional` proceeding notices.
- Keep unknown, mixed, malformed, Repology, and lookup problems actionable.
- Report the ignored notices in the workflow summary.
- Document the ignored notices and the resulting healthy state.

## How to verify

- Run `actionlint workflow-templates/renovate-config-lint.yaml`.
- Run ShellCheck and `bash -n` against the extracted monitor step.
- Exercise the monitor with the current profiler Dashboard and malformed, mixed, and Repology fixtures.
- Run Markdownlint against `docs/workflows/renovate-config-lint.md`.
