### PR TITLE
fix: fix false green json validation in shared super linter config

### DIFF
--- a/config/linters/eslint.config.mjs
+++ b/config/linters/eslint.config.mjs
@@ -2,7 +2,7 @@
 import js from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
-import json from "@eslint/json";
+import jsonc from "eslint-plugin-jsonc";
 
 export default [
   {
@@ -27,11 +27,12 @@ export default [
     },
   },
 
-  {
-    files: ["**/*.json"],
-    ignores: ["**/*.jsonc", "**/*.json5"],
-    plugins: { json },
-    language: "json/json",
-    extends: ["json/recommended"],
-  },
+  // JSON support via eslint-plugin-jsonc, which ships inside the
+  // Super-Linter image (unlike @eslint/json, which is not bundled and
+  // breaks ESM resolution for JAVASCRIPT_ES/JSON/TYPESCRIPT_ES alike,
+  // since Super-Linter loads this single config file for all three).
+  //
+  // "flat/recommended-with-json" is scoped internally to *.json /
+  // **/*.json only — .jsonc and .json5 are left untouched
+  ...jsonc.configs["flat/recommended-with-json"],
 ];

--- a/config/linters/eslint.config.mjs
+++ b/config/linters/eslint.config.mjs
@@ -35,4 +35,22 @@ export default [
   // since Super-Linter loads this single config file for all three).
 
   ...jsonc.configs["flat/recommended-with-json"],
+  ...jsonc.configs["flat/recommended-with-json5"],
+  ...jsonc.configs["flat/recommended-with-jsonc"],
+
+  {
+    files: ["**/*.jsonc"],
+    rules: {
+      "jsonc/no-comments": "off",
+    },
+  },
+
+  {
+    files: ["**/*.json5"],
+    rules: {
+      "jsonc/no-comments": "off",
+      "jsonc/quote-props": "off",
+      "jsonc/comma-dangle": "off",
+    },
+  },
 ];

--- a/config/linters/eslint.config.mjs
+++ b/config/linters/eslint.config.mjs
@@ -29,28 +29,19 @@ export default [
     },
   },
 
-  // JSON support via eslint-plugin-jsonc, which ships inside the
-  // Super-Linter image (unlike @eslint/json, which is not bundled and
-  // breaks ESM resolution for JAVASCRIPT_ES/JSON/TYPESCRIPT_ES alike,
-  // since Super-Linter loads this single config file for all three).
+  ...jsonc.configs["flat/recommended-with-json"].map((config) => ({
+    ...config,
+    files: ["**/*.json"],
+  })),
 
-  ...jsonc.configs["flat/recommended-with-json"],
-  ...jsonc.configs["flat/recommended-with-json5"],
-  ...jsonc.configs["flat/recommended-with-jsonc"],
-
-  {
+  ...jsonc.configs["flat/recommended-with-jsonc"].map((config) => ({
+    ...config,
     files: ["**/*.jsonc"],
-    rules: {
-      "jsonc/no-comments": "off",
-    },
-  },
+  })),
 
-  {
+  ...jsonc.configs["flat/recommended-with-json5"].map((config) => ({
+    ...config,
     files: ["**/*.json5"],
-    rules: {
-      "jsonc/no-comments": "off",
-      "jsonc/quote-props": "off",
-      "jsonc/comma-dangle": "off",
-    },
-  },
+  })),
+
 ];

--- a/config/linters/eslint.config.mjs
+++ b/config/linters/eslint.config.mjs
@@ -2,6 +2,7 @@
 import js from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+import json from "@eslint/json";
 
 export default [
   {
@@ -24,5 +25,13 @@ export default [
       "no-undef": "warn",
       "n/no-missing-import": "warn",
     },
+  },
+
+  {
+    files: ["**/*.json"],
+    ignores: ["**/*.jsonc", "**/*.json5"],
+    plugins: { json },
+    language: "json/json",
+    extends: ["json/recommended"],
   },
 ];

--- a/config/linters/eslint.config.mjs
+++ b/config/linters/eslint.config.mjs
@@ -2,6 +2,7 @@
 import js from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+import nodePlugin from "eslint-plugin-n";
 import jsonc from "eslint-plugin-jsonc";
 
 export default [
@@ -20,6 +21,7 @@ export default [
     },
     plugins: {
       "@typescript-eslint": tseslint,
+      n: nodePlugin,
     },
     rules: {
       "no-undef": "warn",
@@ -31,8 +33,6 @@ export default [
   // Super-Linter image (unlike @eslint/json, which is not bundled and
   // breaks ESM resolution for JAVASCRIPT_ES/JSON/TYPESCRIPT_ES alike,
   // since Super-Linter loads this single config file for all three).
-  //
-  // "flat/recommended-with-json" is scoped internally to *.json /
-  // **/*.json only — .jsonc and .json5 are left untouched
+
   ...jsonc.configs["flat/recommended-with-json"],
 ];


### PR DESCRIPTION
Added eslint configuration for JSON files.
Related Issue: #463 